### PR TITLE
Changed #ifndef WIN32 to #ifdef POSIX to better identify POSIX specif…

### DIFF
--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#ifndef WIN32
+#ifdef POSIX
 #include "port/port_posix.h"
 
 #include <cstdlib>

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#ifndef WIN32
+#ifdef POSIX
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Minor changes to positively identify POSIX code rather then assuming that not WIN32 = POSIX