### PR TITLE
Fixing an issue where a carriage return in the CURRENT file would consider our files as corrupted.

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -916,10 +916,17 @@ Status VersionSet::Recover(bool *save_manifest) {
   if (!s.ok()) {
     return s;
   }
-  if (current.empty() || current[current.size()-1] != '\n') {
+  const size_t size = current.size();
+  if (size == 0 || (current[size - 1] != '\n' && current[size - 1] != '\r')) {
     return Status::Corruption("CURRENT file does not end with newline");
   }
-  current.resize(current.size() - 1);
+
+  int resizeSize = 1;
+  if (size >= 2 && current[size - 2] == '\r') {
+    resizeSize = 2;
+  }
+
+  current.resize(size - resizeSize);
 
   std::string dscname = dbname_ + "/" + current;
   SequentialFile* file;


### PR DESCRIPTION
In some circumstances, we were getting a `CURRENT` file with a carriage return before a new line, and we didn't handle that.  Now we do.