### PR TITLE
Remove redundant header includes

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -39,9 +39,6 @@
 #endif
 
 #include <pthread.h>
-#ifdef SNAPPY
-#include <snappy.h>
-#endif
 #include <stdint.h>
 #include <string>
 #include "port/atomic_pointer.h"

--- a/port/port_win.cc
+++ b/port/port_win.cc
@@ -35,14 +35,6 @@
 #include <windows.h>
 #include <cassert>
 
-#define ZLIB
-
-#ifdef SNAPPY
-	#include <snappy/snappy.h>
-#elif defined(ZLIB)
-	#include <zlib/zlib.h>
-#endif
-
 namespace leveldb {
 namespace port {
 


### PR DESCRIPTION
These headers were needed by code which was removed years ago in this fork (in Google's version the snappy header is needed for `port::Snappy_Compress()` which no longer exists in this version). The requirement to have 2 different paths for zlib includes was a dire headache (`<zlib.h>` vs `<zlib/zlib.h>`).