### PR TITLE
Fix some issues with the leveldb C API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ BENCHMARKS = \
 	doc/bench/db_bench_sqlite3 \
 	doc/bench/db_bench_tree_db
 
-CFLAGS += -I. -I./include $(PLATFORM_CCFLAGS) $(OPT)
+CFLAGS += -DDLLX= -I. -I./include $(PLATFORM_CCFLAGS) $(OPT)
 CXXFLAGS += -DDLLX= -I. -I./include $(PLATFORM_CXXFLAGS) $(OPT)
 
 LDFLAGS += $(PLATFORM_LDFLAGS)

--- a/db/c.cc
+++ b/db/c.cc
@@ -16,7 +16,10 @@
 #include "leveldb/status.h"
 #include "leveldb/write_batch.h"
 #include "leveldb/zlib_compressor.h"
+#ifdef SNAPPY
 #include "leveldb/snappy_compressor.h"
+#endif // SNAPPY
+
 
 using leveldb::Cache;
 using leveldb::Comparator;

--- a/db/c.cc
+++ b/db/c.cc
@@ -15,7 +15,9 @@
 #include "leveldb/options.h"
 #include "leveldb/status.h"
 #include "leveldb/write_batch.h"
+#ifndef NO_ZLIB
 #include "leveldb/zlib_compressor.h"
+#endif // NO_ZLIB
 #ifdef SNAPPY
 #include "leveldb/snappy_compressor.h"
 #endif // SNAPPY
@@ -460,12 +462,14 @@ void leveldb_options_set_compression(leveldb_options_t* opt, int t) {
       opt->rep.compressors[0] = new leveldb::SnappyCompressor();
       break;
 #endif
+#ifndef NO_ZLIB
     case leveldb_zlib_compression:
       opt->rep.compressors[0] = new leveldb::ZlibCompressor();
       break;
     case leveldb_zlib_raw_compression:
       opt->rep.compressors[0] = new leveldb::ZlibCompressorRaw();
       break;
+#endif // !NO_ZLIB
   }
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -5,7 +5,9 @@
 #include "leveldb/c.h"
 
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif // _WIN32
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
 #include "leveldb/db.h"

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -200,6 +200,8 @@ extern DLLX void leveldb_options_set_cache(leveldb_options_t*, leveldb_cache_t*)
 extern DLLX void leveldb_options_set_block_size(leveldb_options_t*, size_t);
 extern DLLX void leveldb_options_set_block_restart_interval(leveldb_options_t*, int);
 
+#define MOJANG_LEVELDB
+
 enum {
   leveldb_no_compression = 0,
   leveldb_snappy_compression = 1,

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -202,13 +202,9 @@ extern DLLX void leveldb_options_set_block_restart_interval(leveldb_options_t*, 
 
 enum {
   leveldb_no_compression = 0,
-#ifdef SNAPPY
   leveldb_snappy_compression = 1,
-#endif
-#ifndef NO_ZLIB
   leveldb_zlib_compression = 2,
   leveldb_zlib_raw_compression = 4
-#endif // !NO_ZLIB
 };
 extern DLLX void leveldb_options_set_compression(leveldb_options_t*, int);
 

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -205,8 +205,10 @@ enum {
 #ifdef SNAPPY
   leveldb_snappy_compression = 1,
 #endif
+#ifndef NO_ZLIB
   leveldb_zlib_compression = 2,
   leveldb_zlib_raw_compression = 4
+#endif // !NO_ZLIB
 };
 extern void leveldb_options_set_compression(leveldb_options_t*, int);
 

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -69,27 +69,27 @@ typedef struct leveldb_writeoptions_t  leveldb_writeoptions_t;
 
 /* DB operations */
 
-extern leveldb_t* leveldb_open(
+extern DLLX leveldb_t* leveldb_open(
     const leveldb_options_t* options,
     const char* name,
     char** errptr);
 
-extern void leveldb_close(leveldb_t* db);
+extern DLLX void leveldb_close(leveldb_t* db);
 
-extern void leveldb_put(
+extern DLLX void leveldb_put(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,
     const char* key, size_t keylen,
     const char* val, size_t vallen,
     char** errptr);
 
-extern void leveldb_delete(
+extern DLLX void leveldb_delete(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,
     const char* key, size_t keylen,
     char** errptr);
 
-extern void leveldb_write(
+extern DLLX void leveldb_write(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,
     leveldb_writebatch_t* batch,
@@ -97,80 +97,80 @@ extern void leveldb_write(
 
 /* Returns NULL if not found.  A malloc()ed array otherwise.
    Stores the length of the array in *vallen. */
-extern char* leveldb_get(
+extern DLLX char* leveldb_get(
     leveldb_t* db,
     const leveldb_readoptions_t* options,
     const char* key, size_t keylen,
     size_t* vallen,
     char** errptr);
 
-extern leveldb_iterator_t* leveldb_create_iterator(
+extern DLLX leveldb_iterator_t* leveldb_create_iterator(
     leveldb_t* db,
     const leveldb_readoptions_t* options);
 
-extern const leveldb_snapshot_t* leveldb_create_snapshot(
+extern DLLX const leveldb_snapshot_t* leveldb_create_snapshot(
     leveldb_t* db);
 
-extern void leveldb_release_snapshot(
+extern DLLX void leveldb_release_snapshot(
     leveldb_t* db,
     const leveldb_snapshot_t* snapshot);
 
 /* Returns NULL if property name is unknown.
    Else returns a pointer to a malloc()-ed null-terminated value. */
-extern char* leveldb_property_value(
+extern DLLX char* leveldb_property_value(
     leveldb_t* db,
     const char* propname);
 
-extern void leveldb_approximate_sizes(
+extern DLLX void leveldb_approximate_sizes(
     leveldb_t* db,
     int num_ranges,
     const char* const* range_start_key, const size_t* range_start_key_len,
     const char* const* range_limit_key, const size_t* range_limit_key_len,
     uint64_t* sizes);
 
-extern void leveldb_compact_range(
+extern DLLX void leveldb_compact_range(
     leveldb_t* db,
     const char* start_key, size_t start_key_len,
     const char* limit_key, size_t limit_key_len);
 
 /* Management operations */
 
-extern void leveldb_destroy_db(
+extern DLLX void leveldb_destroy_db(
     const leveldb_options_t* options,
     const char* name,
     char** errptr);
 
-extern void leveldb_repair_db(
+extern DLLX void leveldb_repair_db(
     const leveldb_options_t* options,
     const char* name,
     char** errptr);
 
 /* Iterator */
 
-extern void leveldb_iter_destroy(leveldb_iterator_t*);
-extern unsigned char leveldb_iter_valid(const leveldb_iterator_t*);
-extern void leveldb_iter_seek_to_first(leveldb_iterator_t*);
-extern void leveldb_iter_seek_to_last(leveldb_iterator_t*);
-extern void leveldb_iter_seek(leveldb_iterator_t*, const char* k, size_t klen);
-extern void leveldb_iter_next(leveldb_iterator_t*);
-extern void leveldb_iter_prev(leveldb_iterator_t*);
-extern const char* leveldb_iter_key(const leveldb_iterator_t*, size_t* klen);
-extern const char* leveldb_iter_value(const leveldb_iterator_t*, size_t* vlen);
-extern void leveldb_iter_get_error(const leveldb_iterator_t*, char** errptr);
+extern DLLX void leveldb_iter_destroy(leveldb_iterator_t*);
+extern DLLX unsigned char leveldb_iter_valid(const leveldb_iterator_t*);
+extern DLLX void leveldb_iter_seek_to_first(leveldb_iterator_t*);
+extern DLLX void leveldb_iter_seek_to_last(leveldb_iterator_t*);
+extern DLLX void leveldb_iter_seek(leveldb_iterator_t*, const char* k, size_t klen);
+extern DLLX void leveldb_iter_next(leveldb_iterator_t*);
+extern DLLX void leveldb_iter_prev(leveldb_iterator_t*);
+extern DLLX const char* leveldb_iter_key(const leveldb_iterator_t*, size_t* klen);
+extern DLLX const char* leveldb_iter_value(const leveldb_iterator_t*, size_t* vlen);
+extern DLLX void leveldb_iter_get_error(const leveldb_iterator_t*, char** errptr);
 
 /* Write batch */
 
-extern leveldb_writebatch_t* leveldb_writebatch_create();
-extern void leveldb_writebatch_destroy(leveldb_writebatch_t*);
-extern void leveldb_writebatch_clear(leveldb_writebatch_t*);
-extern void leveldb_writebatch_put(
+extern DLLX leveldb_writebatch_t* leveldb_writebatch_create();
+extern DLLX void leveldb_writebatch_destroy(leveldb_writebatch_t*);
+extern DLLX void leveldb_writebatch_clear(leveldb_writebatch_t*);
+extern DLLX void leveldb_writebatch_put(
     leveldb_writebatch_t*,
     const char* key, size_t klen,
     const char* val, size_t vlen);
-extern void leveldb_writebatch_delete(
+extern DLLX void leveldb_writebatch_delete(
     leveldb_writebatch_t*,
     const char* key, size_t klen);
-extern void leveldb_writebatch_iterate(
+extern DLLX void leveldb_writebatch_iterate(
     leveldb_writebatch_t*,
     void* state,
     void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),
@@ -178,27 +178,27 @@ extern void leveldb_writebatch_iterate(
 
 /* Options */
 
-extern leveldb_options_t* leveldb_options_create();
-extern void leveldb_options_destroy(leveldb_options_t*);
-extern void leveldb_options_set_comparator(
+extern DLLX leveldb_options_t* leveldb_options_create();
+extern DLLX void leveldb_options_destroy(leveldb_options_t*);
+extern DLLX void leveldb_options_set_comparator(
     leveldb_options_t*,
     leveldb_comparator_t*);
-extern void leveldb_options_set_filter_policy(
+extern DLLX void leveldb_options_set_filter_policy(
     leveldb_options_t*,
     leveldb_filterpolicy_t*);
-extern void leveldb_options_set_create_if_missing(
+extern DLLX void leveldb_options_set_create_if_missing(
     leveldb_options_t*, unsigned char);
-extern void leveldb_options_set_error_if_exists(
+extern DLLX void leveldb_options_set_error_if_exists(
     leveldb_options_t*, unsigned char);
-extern void leveldb_options_set_paranoid_checks(
+extern DLLX void leveldb_options_set_paranoid_checks(
     leveldb_options_t*, unsigned char);
-extern void leveldb_options_set_env(leveldb_options_t*, leveldb_env_t*);
-extern void leveldb_options_set_info_log(leveldb_options_t*, leveldb_logger_t*);
-extern void leveldb_options_set_write_buffer_size(leveldb_options_t*, size_t);
-extern void leveldb_options_set_max_open_files(leveldb_options_t*, int);
-extern void leveldb_options_set_cache(leveldb_options_t*, leveldb_cache_t*);
-extern void leveldb_options_set_block_size(leveldb_options_t*, size_t);
-extern void leveldb_options_set_block_restart_interval(leveldb_options_t*, int);
+extern DLLX void leveldb_options_set_env(leveldb_options_t*, leveldb_env_t*);
+extern DLLX void leveldb_options_set_info_log(leveldb_options_t*, leveldb_logger_t*);
+extern DLLX void leveldb_options_set_write_buffer_size(leveldb_options_t*, size_t);
+extern DLLX void leveldb_options_set_max_open_files(leveldb_options_t*, int);
+extern DLLX void leveldb_options_set_cache(leveldb_options_t*, leveldb_cache_t*);
+extern DLLX void leveldb_options_set_block_size(leveldb_options_t*, size_t);
+extern DLLX void leveldb_options_set_block_restart_interval(leveldb_options_t*, int);
 
 enum {
   leveldb_no_compression = 0,
@@ -210,11 +210,11 @@ enum {
   leveldb_zlib_raw_compression = 4
 #endif // !NO_ZLIB
 };
-extern void leveldb_options_set_compression(leveldb_options_t*, int);
+extern DLLX void leveldb_options_set_compression(leveldb_options_t*, int);
 
 /* Comparator */
 
-extern leveldb_comparator_t* leveldb_comparator_create(
+extern DLLX leveldb_comparator_t* leveldb_comparator_create(
     void* state,
     void (*destructor)(void*),
     int (*compare)(
@@ -222,11 +222,11 @@ extern leveldb_comparator_t* leveldb_comparator_create(
         const char* a, size_t alen,
         const char* b, size_t blen),
     const char* (*name)(void*));
-extern void leveldb_comparator_destroy(leveldb_comparator_t*);
+extern DLLX void leveldb_comparator_destroy(leveldb_comparator_t*);
 
 /* Filter policy */
 
-extern leveldb_filterpolicy_t* leveldb_filterpolicy_create(
+extern DLLX leveldb_filterpolicy_t* leveldb_filterpolicy_create(
     void* state,
     void (*destructor)(void*),
     char* (*create_filter)(
@@ -239,40 +239,40 @@ extern leveldb_filterpolicy_t* leveldb_filterpolicy_create(
         const char* key, size_t length,
         const char* filter, size_t filter_length),
     const char* (*name)(void*));
-extern void leveldb_filterpolicy_destroy(leveldb_filterpolicy_t*);
+extern DLLX void leveldb_filterpolicy_destroy(leveldb_filterpolicy_t*);
 
-extern leveldb_filterpolicy_t* leveldb_filterpolicy_create_bloom(
+extern DLLX leveldb_filterpolicy_t* leveldb_filterpolicy_create_bloom(
     int bits_per_key);
 
 /* Read options */
 
-extern leveldb_readoptions_t* leveldb_readoptions_create();
-extern void leveldb_readoptions_destroy(leveldb_readoptions_t*);
-extern void leveldb_readoptions_set_verify_checksums(
+extern DLLX leveldb_readoptions_t* leveldb_readoptions_create();
+extern DLLX void leveldb_readoptions_destroy(leveldb_readoptions_t*);
+extern DLLX void leveldb_readoptions_set_verify_checksums(
     leveldb_readoptions_t*,
     unsigned char);
-extern void leveldb_readoptions_set_fill_cache(
+extern DLLX void leveldb_readoptions_set_fill_cache(
     leveldb_readoptions_t*, unsigned char);
-extern void leveldb_readoptions_set_snapshot(
+extern DLLX void leveldb_readoptions_set_snapshot(
     leveldb_readoptions_t*,
     const leveldb_snapshot_t*);
 
 /* Write options */
 
-extern leveldb_writeoptions_t* leveldb_writeoptions_create();
-extern void leveldb_writeoptions_destroy(leveldb_writeoptions_t*);
-extern void leveldb_writeoptions_set_sync(
+extern DLLX leveldb_writeoptions_t* leveldb_writeoptions_create();
+extern DLLX void leveldb_writeoptions_destroy(leveldb_writeoptions_t*);
+extern DLLX void leveldb_writeoptions_set_sync(
     leveldb_writeoptions_t*, unsigned char);
 
 /* Cache */
 
-extern leveldb_cache_t* leveldb_cache_create_lru(size_t capacity);
-extern void leveldb_cache_destroy(leveldb_cache_t* cache);
+extern DLLX leveldb_cache_t* leveldb_cache_create_lru(size_t capacity);
+extern DLLX void leveldb_cache_destroy(leveldb_cache_t* cache);
 
 /* Env */
 
-extern leveldb_env_t* leveldb_create_default_env();
-extern void leveldb_env_destroy(leveldb_env_t*);
+extern DLLX leveldb_env_t* leveldb_create_default_env();
+extern DLLX void leveldb_env_destroy(leveldb_env_t*);
 
 /* Utility */
 
@@ -281,13 +281,13 @@ extern void leveldb_env_destroy(leveldb_env_t*);
    in this file.  Note that in certain cases (typically on Windows), you
    may need to call this routine instead of free(ptr) to dispose of
    malloc()-ed memory returned by this library. */
-extern void leveldb_free(void* ptr);
+extern DLLX void leveldb_free(void* ptr);
 
 /* Return the major version number for this release. */
-extern int leveldb_major_version();
+extern DLLX int leveldb_major_version();
 
 /* Return the minor version number for this release. */
-extern int leveldb_minor_version();
+extern DLLX int leveldb_minor_version();
 
 #ifdef __cplusplus
 }  /* end extern "C" */


### PR DESCRIPTION
This PR fixes a range of issues with the C API, listed below:

- There was an issue with compiling with the C API included on Windows due to snappy not being present to be linked. This was fixed by not including the Snappy compressor header when `SNAPPY` is not defined.
- `NO_ZLIB` was a nice way to simply break your build - it was impossible to compile with zlib disabled. Since the Zlib compressor respects the `NO_ZLIB` macro, I've propagated that to other areas that use zlib to allow it to be disabled properly.
- `unistd.h` doesn't exist on Windows and isn't needed - `ifndef`'d it out. It's possible it might not be needed at all, but I'm not 100% sure of that.
- DLL exports have been added to the C API using the `DLLX` macro to allow using the C API when leveldb is built as a DLL.

I've kept the commits separate so you can cherry-pick if you choose.