### PR TITLE
Fixed compile error on Windows due to ssize_t not being defined

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -14,6 +14,11 @@
 #include "util/mutexlock.h"
 #include "util/random.h"
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+ typedef SSIZE_T ssize_t;
+#endif
+
 namespace leveldb {
 
 #if 0


### PR DESCRIPTION
This is separate from my other changes because I don't know how you guys handle this internally (maybe a define in the project files (which are conspicuously missing from the repo :P)?) but this solves the problem regardless.

If this doesn't fit with how you guys handle this, feel free to close the PR, but this is more convenient than any VS-specified preprocessor define.