### PR TITLE
Added accessor function to set compressors in `Options` objects.

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -447,6 +447,26 @@ void leveldb_options_set_block_restart_interval(leveldb_options_t* opt, int n) {
   opt->rep.block_restart_interval = n;
 }
 
+// Acces to the compressor member of Options
+void leveldb_options_set_compressor(leveldb_options_t* opt, int i, int t) {
+  switch(t) {
+    case 0:
+      opt->rep.compressors[i] = nullptr;
+      break;
+#ifdef SNAPPY
+    case leveldb_snappy_compression:
+      opt->rep.compressors[i] = new leveldb::SnappyCompressor();
+      break;
+#endif
+    case leveldb_zlib_compression:
+      opt->rep.compressors[i] = new leveldb::ZlibCompressor();
+      break;
+    case leveldb_zlib_raw_compression:
+      opt->rep.compressors[i] = new leveldb::ZlibCompressorRaw();
+      break;
+  }
+}
+
 void leveldb_options_set_compression(leveldb_options_t* opt, int t) {
   switch(t) {
     case 0:

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -210,6 +210,9 @@ enum {
 };
 extern void leveldb_options_set_compression(leveldb_options_t*, int);
 
+// Acces to the compressor member of Options
+extern void leveldb_options_set_compressor(leveldb_options_t*, int, int);
+
 /* Comparator */
 
 extern leveldb_comparator_t* leveldb_comparator_create(


### PR DESCRIPTION
Call `leveldb_options_set_compressor(leveldb_options_t* opt, int i, int t)`
where `leveldb_options_t* opt` is the `Options` object, `int i` is the index
in the `compressor` array to be set and `int t` is the compressor type.

When developing MCEdit-Unified, I found it was missing.
Instead writing a wrapper around leveldb-mcpe, it may be interesting to have this directly in the code.