### PR TITLE
Fixed repair to skip corrupted keys that it can't parse.

### DIFF
--- a/db/repair.cc
+++ b/db/repair.cc
@@ -334,9 +334,12 @@ class Repairer {
     // Copy data.
     Iterator* iter = NewTableIterator(t.meta);
     int counter = 0;
+    ParsedInternalKey parsed;
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-      builder->Add(iter->key(), iter->value());
-      counter++;
+      if (ParseInternalKey(iter->key(), &parsed)) {
+        builder->Add(iter->key(), iter->value());
+        counter++;
+      }
     }
     delete iter;
 


### PR DESCRIPTION
Some users have corrupted worlds for unknown reasons. Manual inspection showed that they had invalid keys in them (size < 8) which leveldb can't parse. This caused every write to the database to fail. Strangely enough the repair functionality required all keys to be valid. This PR changes that so it instead skips the invalid keys if there are any. The world might still be slightly invalid (data could have been dropped) but it's much better than being completely broken.