### PR TITLE
Fix call to FormatMessageW to specify proper value for array size

### DIFF
--- a/util/env_winrt.cc
+++ b/util/env_winrt.cc
@@ -57,12 +57,12 @@ namespace leveldb {
 
 		static Status GetLastWindowsError(const std::string& name) {
 			WCHAR lpBuffer[256] = L"?";
-			FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM,                 // It´s a system error
+			FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM,                 // It's a system error
 				NULL,                                      // No string to be formatted needed
 				GetLastError(),                               // Hey Windows: Please explain this error!
 				MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),  // Do it in the standard language
 				lpBuffer,              // Put the message here
-				(sizeof(lpBuffer) / sizeof(WCHAR)) - 1,     // Number of characters to store the message
+				(sizeof(lpBuffer) / sizeof(WCHAR)),         // Number of characters to store the message
 				NULL);
 			return Status::IOError(name, ws2s(lpBuffer).c_str());
 		}

--- a/util/env_winrt.cc
+++ b/util/env_winrt.cc
@@ -62,7 +62,7 @@ namespace leveldb {
 				GetLastError(),                               // Hey Windows: Please explain this error!
 				MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),  // Do it in the standard language
 				lpBuffer,              // Put the message here
-				sizeof(lpBuffer) - 1,                     // Number of bytes to store the message
+				(sizeof(lpBuffer) / sizeof(WCHAR)) - 1,     // Number of bytes to store the message
 				NULL);
 			return Status::IOError(name, ws2s(lpBuffer).c_str());
 		}

--- a/util/env_winrt.cc
+++ b/util/env_winrt.cc
@@ -62,7 +62,7 @@ namespace leveldb {
 				GetLastError(),                               // Hey Windows: Please explain this error!
 				MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),  // Do it in the standard language
 				lpBuffer,              // Put the message here
-				(sizeof(lpBuffer) / sizeof(WCHAR)) - 1,     // Number of bytes to store the message
+				(sizeof(lpBuffer) / sizeof(WCHAR)) - 1,     // Number of characters to store the message
 				NULL);
 			return Status::IOError(name, ws2s(lpBuffer).c_str());
 		}


### PR DESCRIPTION
Found this bug when going over code analysis issues. Submitting PR for consideration, if we feel this needs to be fixed or not.