### PR TITLE
Removing references to LEVELDB_ENVIRONMENT_PLUGIN.

### DIFF
--- a/util/env_win.cc
+++ b/util/env_win.cc
@@ -609,8 +609,6 @@ namespace leveldb {
 		return TRUE;
 	}
 
-	// Xbox uses the LevelDB Environment Plugin that goes through Core::FileSystem
-#ifndef LEVELDB_ENVIRONMENT_PLUGIN
 	Env* Env::Default() {
 #if 0
 		PVOID lpContext;
@@ -625,6 +623,5 @@ namespace leveldb {
 
 		return default_env;
 	}
-#endif
 }
 #endif


### PR DESCRIPTION
Removing these references in order to clean up and allow the plugin to be used on all platforms.