### PR TITLE
Story 419757: Omit duplicate symbol already defined in Minecraft.Shared lib

### DIFF
--- a/util/env_win.cc
+++ b/util/env_win.cc
@@ -599,19 +599,18 @@ namespace leveldb {
 		return TRUE;
 	}
 
-	Env* Env::Default() {
 #if 0
+	Env* Env::Default() {
 		PVOID lpContext;
 		InitOnceExecuteOnce(&g_InitOnce,          // One-time initialization structure
 			InitDefaultEnv,   // Pointer to initialization callback function
 			"",                 // Optional parameter to callback function (not used)
 			&lpContext);          // Receives pointer to event object stored in g_InitOnce
-#else
 		if (default_env == NULL)
 			InitDefaultEnv(NULL, NULL, NULL);
-#endif
 
 		return default_env;
 	}
+#endif
 }
 #endif


### PR DESCRIPTION
`Env::Default()` is also defined in https://github.com/Mojang/Minecraftpe/blob/main/handheld/src/common/leveldb/LevelDbEnv.cpp, which results in a duplicate symbol error in Bedrock builds with unity disabled.

I verified that the default build (unity enabled) uses the method in src/common, so do we need this copy at all? The method already does almost nothing:
```
if (default_env == NULL)
    InitDefaultEnv(NULL, NULL, NULL);
```
Since `#if 0` was already there and retaining changes in a third-party lib can make it easier to upgrade, I just expanded it to remove the whole method. Only concern is that I'm missing some other use case...