### PR TITLE
User Story AB#616456: Enable PREFast warnings as errors. [Error Type: C26433: Add override keyword] - Submodule leveldb-mcpe

### DIFF
--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -297,51 +297,51 @@ class DLLX EnvWrapper : public Env {
   Env* target() const { return target_; }
 
   // The following text is boilerplate that forwards all methods to target()
-  Status NewSequentialFile(const std::string& f, SequentialFile** r) {
+  Status NewSequentialFile(const std::string& f, SequentialFile** r) override {
     return target_->NewSequentialFile(f, r);
   }
-  Status NewRandomAccessFile(const std::string& f, RandomAccessFile** r) {
+  Status NewRandomAccessFile(const std::string& f, RandomAccessFile** r) override {
     return target_->NewRandomAccessFile(f, r);
   }
-  Status NewWritableFile(const std::string& f, WritableFile** r) {
+  Status NewWritableFile(const std::string& f, WritableFile** r) override {
     return target_->NewWritableFile(f, r);
   }
-  Status NewAppendableFile(const std::string& f, WritableFile** r) {
+  Status NewAppendableFile(const std::string& f, WritableFile** r) override {
     return target_->NewAppendableFile(f, r);
   }
-  bool FileExists(const std::string& f) { return target_->FileExists(f); }
-  Status GetChildren(const std::string& dir, std::vector<std::string>* r) {
+  bool FileExists(const std::string& f) override { return target_->FileExists(f); }
+  Status GetChildren(const std::string& dir, std::vector<std::string>* r) override {
     return target_->GetChildren(dir, r);
   }
-  Status DeleteFile(const std::string& f) { return target_->DeleteFile(f); }
-  Status CreateDir(const std::string& d) { return target_->CreateDir(d); }
-  Status DeleteDir(const std::string& d) { return target_->DeleteDir(d); }
-  Status GetFileSize(const std::string& f, uint64_t* s) {
+  Status DeleteFile(const std::string& f) override { return target_->DeleteFile(f); }
+  Status CreateDir(const std::string& d) override { return target_->CreateDir(d); }
+  Status DeleteDir(const std::string& d) override { return target_->DeleteDir(d); }
+  Status GetFileSize(const std::string& f, uint64_t* s) override {
     return target_->GetFileSize(f, s);
   }
-  Status RenameFile(const std::string& s, const std::string& t) {
+  Status RenameFile(const std::string& s, const std::string& t) override {
     return target_->RenameFile(s, t);
   }
-  Status LockFile(const std::string& f, FileLock** l) {
+  Status LockFile(const std::string& f, FileLock** l) override {
     return target_->LockFile(f, l);
   }
-  Status UnlockFile(FileLock* l) { return target_->UnlockFile(l); }
-  void Schedule(void (*f)(void*), void* a) {
+  Status UnlockFile(FileLock* l) override { return target_->UnlockFile(l); }
+  void Schedule(void (*f)(void*), void* a) override {
     return target_->Schedule(f, a);
   }
-  void StartThread(void (*f)(void*), void* a) {
+  void StartThread(void (*f)(void*), void* a) override {
     return target_->StartThread(f, a);
   }
-  virtual Status GetTestDirectory(std::string* path) {
+  virtual Status GetTestDirectory(std::string* path) override {
     return target_->GetTestDirectory(path);
   }
-  virtual Status NewLogger(const std::string& fname, Logger** result) {
+  virtual Status NewLogger(const std::string& fname, Logger** result) override {
     return target_->NewLogger(fname, result);
   }
-  uint64_t NowMicros() {
+  uint64_t NowMicros() override {
     return target_->NowMicros();
   }
-  void SleepForMicroseconds(int micros) {
+  void SleepForMicroseconds(int micros) override {
     target_->SleepForMicroseconds(micros);
   }
  private:


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/616456

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->



### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->
Check with PREFast, found 19 errors:
 1. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(300)	Error C26433	Function 'leveldb::EnvWrapper::NewSequentialFile' should be marked with 'override' (c.128).
2. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(303)	Error C26433	Function 'leveldb::EnvWrapper::NewRandomAccessFile' should be marked with 'override' (c.128).
3. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(306)	Error C26433	Function 'leveldb::EnvWrapper::NewWritableFile' should be marked with 'override' (c.128).
4. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(309)	Error C26433	Function 'leveldb::EnvWrapper::NewAppendableFile' should be marked with 'override' (c.128).
5. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(312)	Error C26433	Function 'leveldb::EnvWrapper::FileExists' should be marked with 'override' (c.128).
6. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(313)	Error C26433	Function 'leveldb::EnvWrapper::GetChildren' should be marked with 'override' (c.128).
7. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(316)	Error C26433	Function 'leveldb::EnvWrapper::DeleteFileA' should be marked with 'override' (c.128).
8. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(317)	Error C26433	Function 'leveldb::EnvWrapper::CreateDir' should be marked with 'override' (c.128).
9. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(318)	Error C26433	Function 'leveldb::EnvWrapper::DeleteDir' should be marked with 'override' (c.128).
10. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(319)	Error C26433	Function 'leveldb::EnvWrapper::GetFileSize' should be marked with 'override' (c.128).
11. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(322)	Error C26433	Function 'leveldb::EnvWrapper::RenameFile' should be marked with 'override' (c.128).
12. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(325)	Error C26433	Function 'leveldb::EnvWrapper::LockFile' should be marked with 'override' (c.128).
13. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(328)	Error C26433	Function 'leveldb::EnvWrapper::UnlockFile' should be marked with 'override' (c.128).
14. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(329)	Error C26433	Function 'leveldb::EnvWrapper::Schedule' should be marked with 'override' (c.128).
15. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(332)	Error C26433	Function 'leveldb::EnvWrapper::StartThread' should be marked with 'override' (c.128).
16. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(335)	Error C26433	Function 'leveldb::EnvWrapper::GetTestDirectory' should be marked with 'override' (c.128).
17. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(338)	Error C26433	Function 'leveldb::EnvWrapper::NewLogger' should be marked with 'override' (c.128).
18. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(341)	Error C26433	Function 'leveldb::EnvWrapper::NowMicros' should be marked with 'override' (c.128).
19. C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\env.h(344)	Error C26433	Function 'leveldb::EnvWrapper::SleepForMicroseconds' should be marked with 'override' (c.128).

The modifications are as following:
According to modification suggestions, **mark it with 'override'.**


### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->
Synchronize with main on 2021-09-28.


### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [x] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [x] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [x] Correct target branch.
- [x] Reason/root cause understood; documented in Description / PR Commit message.
- [x] Architecturally fits accepted patterns.
- [x] Introduced no known bugs and is secure.
- [x] No hard-coded "secrets".
- [x] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [x] Content creator impact is understood and acceptable.
