### PR TITLE
User Story 768790: Get zlib working for a single platform in main (Conan)

### DIFF
--- a/port/port_win.cc
+++ b/port/port_win.cc
@@ -40,7 +40,7 @@
 #ifdef SNAPPY
 	#include <snappy/snappy.h>
 #elif defined(ZLIB)
-	#include <zlib/zlib.h>
+	#include <zlib.h>
 #endif
 
 namespace leveldb {


### PR DESCRIPTION
## Description
https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/768790

The extra zlib directory before the zlib.h header is not necessary here and needs to be adjusted in order to work with the conan package for zlib.

## Related PR
https://github.com/Mojang/Minecraftpe/pull/37354
