### PR TITLE
performance improvement minimizing flushing to disk

### DIFF
--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -78,6 +78,10 @@ Status Writer::AddRecord(const Slice& slice) {
     left -= fragment_length;
     begin = false;
   } while (s.ok() && left > 0);
+  // flush once for all 
+  if (s.ok()) {
+    s = Flush();
+  }
   return s;
 }
 
@@ -100,12 +104,13 @@ Status Writer::EmitPhysicalRecord(RecordType t, const char* ptr, size_t n) {
   Status s = dest_->Append(Slice(buf, kHeaderSize));
   if (s.ok()) {
     s = dest_->Append(Slice(ptr, n));
-    if (s.ok()) {
-      s = dest_->Flush();
-    }
   }
   block_offset_ += kHeaderSize + n;
   return s;
+}
+
+Status Writer::Flush() {
+  return dest_->Flush();
 }
 
 }  // namespace log

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -42,6 +42,7 @@ class Writer {
   uint32_t type_crc_[kMaxRecordType + 1];
 
   Status EmitPhysicalRecord(RecordType type, const char* ptr, size_t length);
+  Status Flush();
 
   // No copying allowed
   Writer(const Writer&);


### PR DESCRIPTION
This change drastically improves save times by limiting a flush to the end of appending all the records
Before:
![image](https://user-images.githubusercontent.com/58703857/165396043-02a2e2c7-56be-4156-adf5-82e764129af4.png)
After: 
![image](https://user-images.githubusercontent.com/58703857/165396424-6e60d48b-c777-4fd2-81f5-8cd108ac11bd.png)
